### PR TITLE
[WIP] Introduce generic header to accomodate Eth and Non-Eth blocks

### DIFF
--- a/bftengine/include/bftengine/ReplicaConfig.hpp
+++ b/bftengine/include/bftengine/ReplicaConfig.hpp
@@ -150,12 +150,16 @@ class ReplicaConfig : public concord::serialize::SerializableFactory<ReplicaConf
   // Reconfiguration credentials
   CONFIG_PARAM(pathToOperatorPublicKey_, std::string, "", "Path to the operator public key pem file");
   CONFIG_PARAM(operatorEnabled_, bool, true, "true if operator is enabled");
+
   // Pruning parameters
   CONFIG_PARAM(pruningEnabled_, bool, false, "Enable pruning");
   CONFIG_PARAM(numBlocksToKeep_, uint64_t, 0, "how much blocks to keep while pruning");
 
   CONFIG_PARAM(debugPersistentStorageEnabled, bool, false, "whether persistent storage debugging is enabled");
   CONFIG_PARAM(deleteMetricsDumpInterval, uint64_t, 300, "delete metrics dump interval (s)");
+
+  // Storage
+  CONFIG_PARAM(ethDeployment, bool, false, "Ethereum deployment?");
 
   // Messages
   CONFIG_PARAM(maxExternalMessageSize, uint32_t, 131072, "maximum size of external message");
@@ -385,6 +389,7 @@ class ReplicaConfig : public concord::serialize::SerializableFactory<ReplicaConf
 
     serialize(outStream, debugPersistentStorageEnabled);
     serialize(outStream, deleteMetricsDumpInterval);
+    serialize(outStream, ethDeployment);
     serialize(outStream, maxExternalMessageSize);
     serialize(outStream, maxReplyMessageSize);
     serialize(outStream, maxNumOfReservedPages);
@@ -487,6 +492,7 @@ class ReplicaConfig : public concord::serialize::SerializableFactory<ReplicaConf
 
     deserialize(inStream, debugPersistentStorageEnabled);
     deserialize(inStream, deleteMetricsDumpInterval);
+    deserialize(inStream, ethDeployment);
     deserialize(inStream, maxExternalMessageSize);
     deserialize(inStream, maxReplyMessageSize);
     deserialize(inStream, maxNumOfReservedPages);
@@ -627,7 +633,8 @@ inline std::ostream& operator<<(std::ostream& os, const ReplicaConfig& rc) {
               rc.useUnifiedCertificates,
               rc.kvBlockchainVersion,
               replicaMsgSignAlgo,
-              operatorMsgSignAlgo);
+              operatorMsgSignAlgo,
+              rc.ethDeployment);
   os << ", ";
   for (auto& [param, value] : rc.config_params_) os << param << ": " << value << "\n";
   return os;

--- a/kvbc/CMakeLists.txt
+++ b/kvbc/CMakeLists.txt
@@ -36,10 +36,12 @@ add_library(kvbc  src/ClientImp.cpp
     src/kvbc_adapter/categorization/app_state_adapter.cpp
     src/kvbc_adapter/categorization/blocks_deleter_adapter.cpp
 
+    src/kvbc_adapter/v4blockchain/blocks_adder_adapter.cpp
     src/kvbc_adapter/v4blockchain/blocks_deleter_adapter.cpp
     src/kvbc_adapter/v4blockchain/app_state_adapter.cpp
 
     src/kvbc_adapter/replica_adapter.cpp
+    src/block_header.cpp
 )
 
 if (BUILD_ROCKSDB_STORAGE)

--- a/kvbc/cmf/categorized_kvbc_msgs.cmf
+++ b/kvbc/cmf/categorized_kvbc_msgs.cmf
@@ -115,6 +115,49 @@ Msg ParentDigest 2006 {
     fixedlist uint8 32 value
 }
 
+Msg BlockHeaderData 2007 {
+    int64 version
+    int64 number
+    fixedlist uint8 32 parent_hash
+    list fixedlist uint8 32 transactions
+    int64 timestamp
+    int64 gas_limit
+    int64 gas_used
+    fixedlist uint8 32 stateroot
+    fixedlist uint8 32 extra_data
+    fixedlist uint8 32 miner
+    fixedlist uint8 8 nonce
+}
+
+Msg TransactionData 2008 {
+    int64 version
+    int64 block_number
+    int64 nonce
+    fixedlist uint8 20 from
+    fixedlist uint8 20 to
+    fixedlist uint8 20 contract_address
+    bytes input
+    int64 status
+    fixedlist uint8 32 value
+    int64 gas_price
+    int64 gas_limit
+    fixedlist uint8 32 sig_r
+    fixedlist uint8 32 sig_s
+    uint32 sig_v
+    int64 gas_used
+}
+
+Msg LogData 2009 {
+    fixedlist uint8 20 address
+    list fixedlist uint8 32 topic
+    bytes data
+}
+
+Msg TransactionLogData 2010 {
+    int64 version
+    list LogData logs
+}
+
 # Misc
 
 Msg BenchmarkMessage 3000 {

--- a/kvbc/include/block_header.hpp
+++ b/kvbc/include/block_header.hpp
@@ -1,0 +1,45 @@
+// Copyright (c) 2023 VMware, Inc. All Rights Reserved.
+//
+// This product is licensed to you under the Apache 2.0 license (the
+// "License").  You may not use this product except in compliance with the
+// Apache 2.0 License.
+//
+// This product may include a number of subcomponents with separate copyright
+// notices and license terms. Your use of these subcomponents is subject to the
+// terms and conditions of the subcomponent's license, as noted in the LICENSE
+// file.
+//
+#pragma once
+#include <vector>
+#include <string>
+#include "util/serializable.hpp"
+#include "crypto/digest.hpp"
+#include "kvbc_app_filter/kvbc_key_types.h"
+
+namespace concord::kvbc {
+
+const int64_t kBlockStorageVersion = 1;
+using uint256be = std::array<uint8_t, 32>;
+using nonce_t = std::array<uint8_t, 8>;
+
+typedef struct BlockHeader {
+  uint64_t number;
+  uint64_t timestamp;
+  uint256be parent_hash;
+  uint256be stateroot;
+  uint64_t gas_limit;
+  uint64_t gas_used;
+  std::vector<uint256be> transactions;
+  uint256be extra_data;
+  uint256be miner;
+  nonce_t nonce;
+
+  static const auto kHashSizeInBytes = 32;
+  static const std::string blockNumAsKeyToBlockHash(const uint8_t *bytes, size_t length);
+  static const std::string blockNumAsKeyToBlockHeader(const uint8_t *bytes, size_t length);
+  uint256be hash() const;
+  std::string serialize() const;
+  static struct BlockHeader deserialize(const std::string &input);
+} BlockHeader;
+
+}  // namespace concord::kvbc

--- a/kvbc/include/kvbc_adapter/v4blockchain/blocks_adder_adapter.hpp
+++ b/kvbc/include/kvbc_adapter/v4blockchain/blocks_adder_adapter.hpp
@@ -17,6 +17,7 @@
 
 #include "db_interfaces.h"
 #include "v4blockchain/v4_blockchain.h"
+#include "block_header.hpp"
 
 using concord::storage::rocksdb::NativeClient;
 
@@ -28,12 +29,10 @@ class BlocksAdderAdapter : public IBlockAdder {
   explicit BlocksAdderAdapter(std::shared_ptr<concord::kvbc::v4blockchain::KeyValueBlockchain> &kvbc)
       : kvbc_{kvbc.get()} {}
 
-  /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-  // IBlockAdder
-  BlockId add(concord::kvbc::categorization::Updates &&updates) override final {
-    return kvbc_->add(std::move(updates));
-  }
-  /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+  BlockId add(concord::kvbc::categorization::Updates &&updates) override final;
+
+ protected:
+  void getParentHeaderHash_(const BlockId number, uint256be &parent_hash);
 
  private:
   concord::kvbc::v4blockchain::KeyValueBlockchain *kvbc_{nullptr};

--- a/kvbc/include/kvbc_app_filter/kvbc_key_types.h
+++ b/kvbc/include/kvbc_app_filter/kvbc_key_types.h
@@ -27,7 +27,7 @@ const char kKvbKeyEthNonce = 0x06;
 const char kKvbKeyEthBlockHash = 0x07;
 const char kKvbKeyEthEventLog = 0x08;
 
-// Unused 0x10 - 0x1f
+// Unused 0x11 - 0x1f
 
 // Concord 0x20 - 0x2f
 const char kKvbKeyTimeSamples = 0x20;

--- a/kvbc/include/kvbc_key_types.hpp
+++ b/kvbc/include/kvbc_key_types.hpp
@@ -16,6 +16,9 @@
 #include <string>
 
 namespace concord::kvbc::keyTypes {
+
+static const char kKvbKeyBlockHeaderHash = 0x10;
+
 static const char bft_seq_num_key = 0x21;
 static const char reconfiguration_pruning_key = 0x24;
 static const char reconfiguration_prune_compact_key = 0x25;

--- a/kvbc/proto/concord_kvbc.proto
+++ b/kvbc/proto/concord_kvbc.proto
@@ -27,48 +27,6 @@ message ValueWithTrids {
    optional google.protobuf.Timestamp expires_after = 3;
 }
 
-message Block {
-   optional int64 version = 1;
-   optional int64 number = 2;
-   optional bytes hash = 3;             // 32 bytes
-   optional bytes parent_hash = 4;      // 32 bytes
-   repeated bytes transaction = 5;      // 32 bytes
-   optional int64 timestamp = 6;
-   optional int64 gas_limit = 7;
-   optional int64 gas_used = 8;
-   optional bytes stateroot = 9;
-}
-
-message Transaction {
-   optional int64 version = 1;
-   optional int64 block_number = 2;
-   optional int64 nonce = 3;
-   optional bytes block_hash = 4;       // 32 bytes
-   optional bytes from = 5;             // 20 bytes
-   optional bytes to = 6;               // 20 bytes
-   optional bytes contract_address = 7; // 20 bytes
-   optional bytes input = 8;
-   optional int64 status = 9;
-   optional bytes value = 10;
-   optional int64 gas_price = 11;
-   optional int64 gas_limit = 12;
-   optional bytes sig_r = 13;           // 32 bytes
-   optional bytes sig_s = 14;           // 32 bytes
-   optional uint32 sig_v = 15;
-   optional int64 gas_used = 16;
-}
-
-message Log {
-   optional bytes address = 1;          // 20 bytes
-   repeated bytes topic = 2;            // 32 bytes each
-   optional bytes data = 3;
-}
-
-message TransactionLog {
-   optional int64 version = 1;
-   repeated Log logs = 2;
-}
-
 message Balance {
    optional int64 version = 1;
    optional bytes balance = 2;          // 32 bytes

--- a/kvbc/src/block_header.cpp
+++ b/kvbc/src/block_header.cpp
@@ -1,0 +1,120 @@
+// Concord
+//
+// Copyright (c) 2023 VMware, Inc. All Rights Reserved.
+//
+// This product is licensed to you under the Apache 2.0 license (the "License").
+// You may not use this product except in compliance with the Apache 2.0
+// License.
+//
+// This product may include a number of subcomponents with separate copyright
+// notices and license terms. Your use of these subcomponents is subject to the
+// terms and conditions of the subcomponent's license, as noted in the
+// LICENSE file.
+
+#include <string.h>
+
+#include "block_header.hpp"
+#include "log/logger.hpp"
+#include "kvbc_key_types.hpp"
+#include "categorized_kvbc_msgs.cmf.hpp"
+
+using concord::kvbc::categorization::BlockHeaderData;
+using namespace concord::serialize;
+using concord::kvbc::keyTypes::kKvbKeyBlockHeaderHash;
+
+namespace concord::kvbc {
+
+std::string BlockHeader::serialize() const {
+  BlockHeaderData out;
+
+  out.version = kBlockStorageVersion;
+  out.number = number;
+  std::copy(parent_hash.begin(), parent_hash.end(), out.parent_hash.begin());
+  // TODO - reserve once and then use index?
+  for (int i = 0; i < transactions.size(); i++) {
+    uint256be txn;
+    std::copy(transactions[i].begin(), transactions[i].end(), txn.begin());
+    out.transactions.push_back(txn);
+  }
+  out.timestamp = timestamp;
+  out.gas_limit = gas_limit;
+  out.gas_used = gas_used;
+  std::copy(stateroot.begin(), stateroot.end(), out.stateroot.begin());
+  std::copy(extra_data.begin(), extra_data.end(), out.extra_data.begin());
+  std::copy(miner.begin(), miner.end(), out.miner.begin());
+  std::copy(nonce.begin(), nonce.end(), out.nonce.begin());
+
+  std::string serialized_buffer;
+  categorization::serialize(serialized_buffer, out);
+  ConcordAssert(serialized_buffer.size() > 0);
+  return serialized_buffer;
+}
+
+struct BlockHeader BlockHeader::deserialize(const std::string &input) {
+  BlockHeaderData inblk;
+  categorization::deserialize(input, inblk);
+  if (inblk.version != kBlockStorageVersion) {
+    LOG_ERROR(V4_BLOCK_LOG, "Unknown block storage version " << inblk.version);
+    throw std::runtime_error("Unkown block storage version");
+  }
+  BlockHeader outblk;
+  outblk.number = inblk.number;
+  std::copy(inblk.parent_hash.begin(), inblk.parent_hash.end(), outblk.parent_hash.begin());
+  for (int i = 0; i < inblk.transactions.size(); i++) {
+    uint256be txn;
+    std::copy(inblk.transactions[i].begin(), inblk.transactions[i].end(), txn.begin());
+    outblk.transactions.push_back(txn);
+  }
+  outblk.timestamp = inblk.timestamp;
+  outblk.gas_limit = inblk.gas_limit;
+  outblk.gas_used = inblk.gas_used;
+  std::copy(inblk.stateroot.begin(), inblk.stateroot.end(), outblk.stateroot.begin());
+  std::copy(inblk.extra_data.begin(), inblk.extra_data.end(), outblk.extra_data.begin());
+  std::copy(inblk.miner.begin(), inblk.miner.end(), outblk.miner.begin());
+  std::copy(inblk.nonce.begin(), inblk.nonce.end(), outblk.nonce.begin());
+  return outblk;
+}
+
+const std::string BlockHeader::blockNumAsKeyToBlockHash(const uint8_t *bytes, size_t length) {
+  std::string ret;
+  ret.push_back((char)kKvbKeyBlockHeaderHash);
+  ret.append(reinterpret_cast<const char *>(bytes), length);
+  return ret;
+}
+
+const std::string BlockHeader::blockNumAsKeyToBlockHeader(const uint8_t *bytes, size_t length) {
+  std::string ret;
+  ret.push_back((char)kKvbKeyEthBlockHash);
+  ret.append(reinterpret_cast<const char *>(bytes), length);
+  return ret;
+}
+
+uint256be BlockHeader::hash() const {
+  static_assert(sizeof(crypto::BlockDigest) == sizeof(uint256be), "hash size should be same");
+
+  // TODO - We can't simply call serialize() of this class as we don't want block version to be part of serialized
+  // header ?? auto serialized_header = serialize();
+
+  std::ostringstream os;
+  Serializable::serialize(os, number);
+  Serializable::serialize(os, timestamp);
+  Serializable::serialize(os, reinterpret_cast<const char *>(parent_hash.data()), sizeof(parent_hash));
+  Serializable::serialize(os, reinterpret_cast<const char *>(stateroot.begin()), sizeof(stateroot));
+  Serializable::serialize(os, gas_limit);
+  Serializable::serialize(os, gas_used);
+  for (auto txn : transactions) {
+    Serializable::serialize(os, reinterpret_cast<const char *>(txn.begin()), sizeof(txn));
+  }
+  Serializable::serialize(os, reinterpret_cast<const char *>(extra_data.begin()), sizeof(extra_data));
+  Serializable::serialize(os, reinterpret_cast<const char *>(miner.begin()), sizeof(miner));
+  Serializable::serialize(os, reinterpret_cast<const char *>(nonce.begin()), sizeof(nonce));
+  auto serialized_header = os.str();
+
+  crypto::DigestGenerator digest_generator;
+  uint256be hash;
+  digest_generator.update(reinterpret_cast<const char *>(serialized_header.c_str()), serialized_header.size());
+  digest_generator.writeDigest(reinterpret_cast<char *>(hash.data()));
+  return hash;
+}
+
+}  // namespace concord::kvbc

--- a/kvbc/src/kvbc_adapter/v4blockchain/blocks_adder_adapter.cpp
+++ b/kvbc/src/kvbc_adapter/v4blockchain/blocks_adder_adapter.cpp
@@ -1,0 +1,108 @@
+// Concord
+//
+// Copyright (c) 2023 VMware, Inc. All Rights Reserved.
+//
+// This product is licensed to you under the Apache 2.0 license (the "License").
+// You may not use this product except in compliance with the Apache 2.0
+// License.
+//
+// This product may include a number of subcomponents with separate copyright
+// notices and license terms. Your use of these subcomponents is subject to the
+// terms and conditions of the subcomponent's license, as noted in the LICENSE
+// file.
+
+#include "kvbc_adapter/v4blockchain/blocks_adder_adapter.hpp"
+#include "kvbc_app_filter/kvbc_key_types.h"
+#include "categorization/db_categories.h"
+#include "bftengine/ReplicaConfig.hpp"
+
+using bftEngine::ReplicaConfig;
+
+namespace concord::kvbc::adapter::v4blockchain {
+
+void BlocksAdderAdapter::getParentHeaderHash_(const BlockId number, uint256be &parent_hash) {
+  ConcordAssert(number > 0);
+  auto parent_block_number = number - 1;
+  auto block_num_as_key_to_block_hash =
+      BlockHeader::blockNumAsKeyToBlockHash((uint8_t *)&(parent_block_number), sizeof(number));
+  LOG_DEBUG(
+      GL,
+      KVLOG(parent_block_number,
+            concordUtils::bufferToHex(block_num_as_key_to_block_hash.c_str(), block_num_as_key_to_block_hash.size())));
+  auto opt_val = kvbc_->getLatest(kvbc::categorization::kExecutionPrivateCategory, block_num_as_key_to_block_hash);
+  if (opt_val) {
+    auto val = std::get<kvbc::categorization::VersionedValue>(*opt_val);
+    std::copy(val.data.begin(), val.data.end(), parent_hash.begin());
+  }
+}
+
+BlockId BlocksAdderAdapter::add(concord::kvbc::categorization::Updates &&updates) {
+  if (bftEngine::ReplicaConfig::instance().ethDeployment == true) {
+    auto cat_itr = updates.categoryUpdates().kv.find(kvbc::categorization::kExecutionPrivateCategory);
+
+    BlockHeader header{0};
+    std::string serialized_header;
+
+    // block N in app state == block N + 1 in KVBC
+    auto last_reachable_block_num = kvbc_->getLastReachableBlockId();
+    BlockId to_be_written_block_num = last_reachable_block_num;
+    auto to_be_written_block_header_key =
+        BlockHeader::blockNumAsKeyToBlockHeader((uint8_t *)&to_be_written_block_num, sizeof(to_be_written_block_num));
+    LOG_DEBUG(GL,
+              "key size " << to_be_written_block_header_key.size() << " key hash "
+                          << std::hash<std::string>{}(to_be_written_block_header_key) << " key "
+                          << concordUtils::bufferToHex(to_be_written_block_header_key.c_str(),
+                                                       to_be_written_block_header_key.size()));
+
+    if (cat_itr != updates.categoryUpdates().kv.cend()) {
+      const auto &kvs = std::get<kvbc::categorization::VersionedInput>(cat_itr->second).kv;
+      auto key_itr = kvs.find(to_be_written_block_header_key);
+      if (key_itr != kvs.cend()) {
+        // Eth block; just compute hash of already written header in updates
+        serialized_header = key_itr->second.data;
+        header = BlockHeader::deserialize(serialized_header);
+      }
+    }
+
+    // could not find existing blockheader
+    if (serialized_header.empty()) {
+      // Reconfig block; !Eth block; construct BlockHeader
+      if (last_reachable_block_num) {
+        // we are sure genesis is already written
+        header.number = to_be_written_block_num;
+        getParentHeaderHash_(last_reachable_block_num, header.parent_hash);
+        ConcordAssertEQ(header.parent_hash.empty(), false);
+      }
+
+      // add serialized block header into updates
+      serialized_header = header.serialize();
+      updates.addCategoryIfNotExisting<kvbc::categorization::VersionedInput>(
+          concord::kvbc::categorization::kExecutionPrivateCategory);
+      updates.appendKeyValue<kvbc::categorization::VersionedUpdates>(
+          concord::kvbc::categorization::kExecutionPrivateCategory,
+          std::move(to_be_written_block_header_key),
+          kvbc::categorization::VersionedUpdates::Value{serialized_header, true});
+      LOG_DEBUG(
+          GL,
+          "Eth block number " << to_be_written_block_num << " header size " << serialized_header.size()
+                              << " parent hash "
+                              << concordUtils::bufferToHex(header.parent_hash.begin(), header.parent_hash.size()));
+    }
+
+    // std::array<uint8_t, 32> header_hash{0};
+    // add header hash into updates
+    auto header_hash = header.hash();
+    auto block_num_as_key_to_block_hash =
+        BlockHeader::blockNumAsKeyToBlockHash((uint8_t *)&to_be_written_block_num, sizeof(to_be_written_block_num));
+    updates.appendKeyValue<kvbc::categorization::VersionedUpdates>(
+        concord::kvbc::categorization::kExecutionPrivateCategory,
+        std::move(block_num_as_key_to_block_hash),
+        kvbc::categorization::VersionedUpdates::Value{reinterpret_cast<char *>(header_hash.begin()), true});
+    LOG_DEBUG(GL,
+              "Eth Block number " << to_be_written_block_num << " and its header hash "
+                                  << concordUtils::bufferToHex(header_hash.begin(), header_hash.size()));
+  }
+  return kvbc_->add(std::move(updates));
+}
+
+}  // namespace concord::kvbc::adapter::v4blockchain

--- a/tests/simpleKVBC/TesterReplica/setup.cpp
+++ b/tests/simpleKVBC/TesterReplica/setup.cpp
@@ -85,6 +85,7 @@ std::unique_ptr<TestSetup> TestSetup::ParseArgs(int argc, char** argv) {
     replicaConfig.numOfClientServices = 1;
     replicaConfig.kvBlockchainVersion = 4;
     replicaConfig.useUnifiedCertificates = false;
+    replicaConfig.ethDeployment = false;
     const auto persistMode = PersistencyMode::RocksDB;
     std::string keysFilePrefix;
     std::string commConfigFile;


### PR DESCRIPTION
Introduce generic header to accommodate Ethereum and Non-Ethereum blocks.
Block, Transactions and other relevant definitions would be moved from PROTO to CMF format.

* **Problem Overview**  
V4 blockchain used contain Ethereum blocks and Concord internal blocks together on single blockchain. Ethereum blocks used to get stored in interleaved fashion and all the computation including retrieval of content or parent hash used to get into account only last know Ethereum block. This fix aims to simplify blockchain by bringing uniformity across blocks. 

* **Testing Done**  
- Executed all tests locally.
- Validated block contents with Sirato block explorer